### PR TITLE
fix: split income/withdrawal into separate forms, add server function tests

### DIFF
--- a/app/__tests__/expenses/AddExpensesDialog.test.tsx
+++ b/app/__tests__/expenses/AddExpensesDialog.test.tsx
@@ -18,11 +18,11 @@ describe('Expenses Form', () => {
 		_id: '507f1f77bcf86cd799439011',
 		totals: {
 			total_expenses: { cash: 100, card: 500 },
-			total_pending: { cash: 0, card: 0 },
+			total_pending: { cash: 0, card: 1200 },
 			total_payments_made: { cash: 0, card: 0 }
 		},
-		remaining: { card: 400, cash: 300 },
-		income: { cash: 600, card: 1000 },
+		remaining: { card: 1200, cash: 300 },
+		income: { cash: 400, card: 1700 },
 		added: [],
 		expenses: [
 			{ id: '1T', amount: 100, description: 'Groceries', type: 'cash', date: new Date().getTime(), isPending: false },
@@ -166,7 +166,7 @@ describe('Expenses Form', () => {
 
 	});
 
-	describe('Server function', () => {
+	describe('Server functions', () => {
 		it('should reduce pending amount when expense is linked to pending', async () => {
 			const mockExpense = {
 				description: 'Test expense',
@@ -178,6 +178,26 @@ describe('Expenses Form', () => {
 			};
 			const result = await processAddNewExpense(mockExpense, mockTableData);
 			expect(result.pending[1].amount).toBe(507.5);
+			expect(result.totals.total_expenses.card).toBe(692.5);
+			expect(result.totals.total_pending.card).toBe(1007.5);
+			expect(result.totals.total_payments_made.card).toBe(192.5);
+			expect(result.remaining.card).toBe(1007.5);
+		});
+		it('should turn a pending amount 0 when a payment surpasses pending amount', async () => {
+			const mockExpense = {
+				description: 'Surpassing expense',
+				amount: 600,
+				type: 'card',
+				date: 0,
+				isPending: true,
+				pending_id: 'P3'
+			};
+			const result = await processAddNewExpense(mockExpense, mockTableData);
+			expect(result.pending[0].amount).toBe(0);
+			expect(result.totals.total_expenses.card).toBe(1100);
+			expect(result.totals.total_pending.card).toBe(700);
+			expect(result.totals.total_payments_made.card).toBe(600);
+			expect(result.remaining.card).toBe(600);
 		});
 	});
 

--- a/app/__tests__/expenses/AddIncomeDialog.test.tsx
+++ b/app/__tests__/expenses/AddIncomeDialog.test.tsx
@@ -30,7 +30,7 @@ describe('Income-Form', () => {
 		renderWithQuery(<AddIncomeDialog isOpen={true} handleOpen={jest.fn()} cardAmountRemaining={400} />, queryClient);
 
 		const amount = await screen.findByRole('spinbutton', { name: /amount/i });
-		const submitButton = screen.getByRole('button', { name: /add/i });
+		const submitButton = screen.getByRole('button', { name: /withdraw/i });
 
 		await user.clear(amount);
 		await user.type(amount, '100');
@@ -140,13 +140,14 @@ describe('Income-Form', () => {
 			const user = userEvent.setup();
 			renderWithQuery(<AddIncomeDialog isOpen={true} handleOpen={jest.fn()} cardAmountRemaining={50} />, queryClient);
 			const amount = await screen.findByRole('spinbutton', { name: /amount/i });
-			const submitButton = screen.getByRole('button', { name: /add/i });
+			const submitButton = screen.getByRole('button', { name: /withdraw/i });
 			await user.clear(amount);
 			await user.type(amount, '100');
-			await user.click(submitButton);
+			await user.tab();
 			const alert = await screen.findByRole('alert');
 			expect(alert).toBeInTheDocument();
 			expect(alert).toHaveTextContent(`Amount can't be higher than the remaining in card ($50)`);
+			expect(submitButton).toBeDisabled();
 		});
 
 	});

--- a/app/__tests__/server-functions/expenses/expenses-calculator.test.tsx
+++ b/app/__tests__/server-functions/expenses/expenses-calculator.test.tsx
@@ -1,0 +1,69 @@
+import { AddedIncomeI, ExpensesTableI, PendingExpenseI } from "@/interfaces/expenses";
+import { processAddIncome, processAddPending } from "@/services/expenses-calculator";
+
+describe('Expenses Calculator', () => {
+	const mockTableData: ExpensesTableI = {
+		user_id: 'test@test.com',
+		_id: '507f1f77bcf86cd799439011',
+		totals: {
+			total_expenses: { cash: 100, card: 500 },
+			total_pending: { cash: 0, card: 1200 },
+			total_payments_made: { cash: 0, card: 0 }
+		},
+		remaining: { card: 500, cash: 500 },
+		income: { cash: 600, card: 1000 },
+		added: [],
+		expenses: [
+			{ id: '1T', amount: 100, description: 'Groceries', type: 'cash', date: new Date().getTime(), isPending: false },
+			{ id: '2T', amount: 500, description: 'Rent', type: 'card', date: new Date().getTime(), isPending: false },
+		],
+		pending: [
+			{ id: 'P3', description: 'Pending test 3', amount: 500, type: 'card', fulfilled: false },
+			{ id: 'P4', description: 'Pending test 4', amount: 700, type: 'card', fulfilled: false }
+		],
+		sDate: new Date().getTime(),
+		fDate: 0,
+		status: 'active'
+	};
+
+	describe('Process Add Income', () => {
+		it('adds simple income, return updated added array and remaining correctly', async () => {
+			const newIncome: AddedIncomeI = { date: new Date().getTime(), isWithdrawal: false, card: 0, cash: 200 };
+			const res = await processAddIncome(newIncome, mockTableData);
+			expect(res.added.length).toBe(1);
+			expect(res.added[0].cash).toBe(200);
+			expect(res.remaining.card).toBe(500);//remaining card should stay the same
+			expect(res.remaining.cash).toBe(700);
+		});
+		it('withdraw a given amount, return updated added array and remaining updated properly', async () => {
+			const newIncome: AddedIncomeI = { date: new Date().getTime(), isWithdrawal: true, card: 0, cash: 150 };
+			const res = await processAddIncome(newIncome, mockTableData);
+			expect(res.added.length).toBe(1);
+			// Withdrawal transfers from card to cash (ATM logic: electronic → physical money)
+			expect(res.remaining.card).toBe(350); //remaining card should have changed
+			expect(res.remaining.cash).toBe(650);
+		});
+	});
+
+	describe('Process Add Pending', () => {
+		it('adds new card pending expense', async () => {
+			const newClientPendingExpense: PendingExpenseI = { description: 'Mock pending', type: 'card', amount: 350 };
+			const res = await processAddPending(newClientPendingExpense, mockTableData);
+			expect(res.pending.length).toBe(3);
+			expect(res.pending[2].type).toBe('card');
+			expect(res.pending[2].amount).toBe(350);
+			expect(res.totals.total_pending.card).toBe(1550);
+			expect(res.totals.total_pending.cash).toBe(0);
+		});
+		it('adds new cash pending expense', async () => {
+			const newClientPendingExpense: PendingExpenseI = { description: 'Mock pending cash', type: 'cash', amount: 400 };
+			const res = await processAddPending(newClientPendingExpense, mockTableData);
+			expect(res.pending.length).toBe(3);
+			expect(res.pending[2].type).toBe('cash');
+			expect(res.pending[2].amount).toBe(400);
+			expect(res.totals.total_pending.card).toBe(1200);
+			expect(res.totals.total_pending.cash).toBe(400);
+		});
+	});
+
+});

--- a/app/api/expenses/table/route.ts
+++ b/app/api/expenses/table/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
 			status: 'active'
 		});
 		await client.close();
-		if (!table) return NextResponse.json({ data: null }, { status: 200 });
+		if (!table) return NextResponse.json({ data: null }, { status: 204 });
 		return NextResponse.json({ data: table }, { status: 200 });
 	} catch (error) {
 		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
@@ -29,6 +29,7 @@ export async function POST(request: Request) { //Create new table
 		const { session, client, collection } = await setInitialValues();
 		const lastClosedQuery: { user_id: string, status: 'closed' } = { user_id: session.user.email, status: 'closed' };
 		const lastClosed = await collection.findOne(lastClosedQuery, { sort: { fDate: -1 } });
+		const newPendingArray = lastClosed ? lastClosed.pending.map(p => ({ amount: p.originalAmount, ...p })) : [];
 		const initialTableValues: Omit<ExpensesTableI, 'id' | '_id'> = {
 			user_id: session.user.email,
 			status: 'active',
@@ -39,7 +40,7 @@ export async function POST(request: Request) { //Create new table
 				total_pending: { cash: 0, card: 0 },
 				total_payments_made: { cash: 0, card: 0 }
 			},
-			pending: lastClosed ? lastClosed.pending : [],
+			pending: newPendingArray,
 			expenses: [],
 			added: [],
 			fDate: 0,

--- a/app/api/reports/expenses/route.ts
+++ b/app/api/reports/expenses/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest) {
 		}
 		const table = await collection.findOne(query, { sort: { fDate: -1 } });
 		await client.close();
-		if (!table) return NextResponse.json({ data: null }, { status: 200 });
+		if (!table) return NextResponse.json({ data: null }, { status: 204 });
 		return NextResponse.json({ data: table }, { status: 200 });
 	} catch (error) {
 		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,7 @@
 	--foreground-rgb: 0, 0, 0;
 	--background-start-rgb: 149 228 254 / 47%;
 	--background-end-rgb: 255, 255, 255;
+	--stroke-color: rgba(209, 226, 60, 0.9);
 }
 
 /*

--- a/components/simpleTable/income/AddIncomeDialog.tsx
+++ b/components/simpleTable/income/AddIncomeDialog.tsx
@@ -39,6 +39,9 @@ export default function AddIncomeDialog({ isOpen, handleOpen, cardAmountRemainin
 	const [isWithdrawalView, setIsWithdrawalView] = useState<boolean>(true);
 	const { register, handleSubmit, reset, formState: { errors, isSubmitting }, getValues } =
 		useForm<IncomeFormValues>({ mode: 'onSubmit', values: { card: 0, cash: 0, withdrawal: 1 } });
+	const { register: withdrawalRegister, handleSubmit: submitWithdrawal, reset: resetWithdrawal,
+		formState: { errors: err, isSubmitting: isSubmittingWithdrawal, isValid }
+	} = useForm<{ withdrawal: number }>({ mode: 'onChange', values: { withdrawal: 1 } });
 
 	const { mutation } = useAddIncome();
 
@@ -65,56 +68,83 @@ export default function AddIncomeDialog({ isOpen, handleOpen, cardAmountRemainin
 		if (res.ok) {
 			handleOpen(false);
 			reset();
+			resetWithdrawal();
 		}
 	};
 
 
 	const newIncome = (<>
-		<div className="flex flex-col gap-3">
-			<Typography variant="small" color="blue-gray">
-				{`Add a new income for either cash or card`}
-			</Typography>
-			<div className="flex flex-col items-left">
-				<label htmlFor="cash" className="text-xs text-gray-900 font-semibold ml-1">{'Cash'}</label>
-				<input id="cash" name="cash" type="number" className={`formInput ${errors.cash ? 'inputError' : ''}`} step={0.1}
-					{...register('cash', { required: true, min: 0, valueAsNumber: true, validate: validateAtLeastOnePositive })} />
-				{errors.cash && errors.cash.type === 'required' &&
-					(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`This field is required`}</span>)}
-				{errors.cash && errors.cash.type === 'min' &&
-					(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`Amount must be a positive number or zero`}</span>)}
-				{errors.cash && errors.cash.message &&
-					(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{errors.cash.message || 'One number must be positive'}</span>)}
+		<form onSubmit={handleSubmit(onSubmit)} >
+			<div className="flex flex-col gap-3">
+				<span className="text-sm lg:text-[15px] text-blue-gray-800 antialiased text-center">{`Add a new income for either cash or card`}</span>
+				<div className="flex flex-col items-left">
+					<label htmlFor="cash" className="text-xs text-gray-900 font-semibold ml-1">{'Cash'}</label>
+					<input id="cash" name="cash" type="number" className={`formInput ${errors.cash ? 'inputError' : ''}`} step={0.1}
+						{...register('cash', { required: true, min: 0, valueAsNumber: true, validate: validateAtLeastOnePositive })} />
+					{errors.cash && errors.cash.type === 'required' &&
+						(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`This field is required`}</span>)}
+					{errors.cash && errors.cash.type === 'min' &&
+						(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`Amount must be a positive number or zero`}</span>)}
+					{errors.cash && errors.cash.message &&
+						(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{errors.cash.message || 'One number must be positive'}</span>)}
 
+				</div>
+				<div className="flex flex-col items-left">
+					<label htmlFor="card" className="text-xs text-gray-900 font-semibold ml-1">{'Card'}</label>
+					<input id="card" name="card" type="number" className={`formInput ${errors.card ? 'inputError' : ''}`} step={0.01}
+						{...register('card', { required: true, min: 0, valueAsNumber: true })} />
+					{errors.card && errors.card.type === 'required' &&
+						(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`This field is required`}</span>)}
+					{errors.card && errors.card.type === 'min' &&
+						(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`Amount must be a positive number or zero `}</span>)}
+				</div>
+				<div className="flex w-full justify-end gap-4 mt-4">
+					<Button variant="filled" className="filled"
+						loading={isSubmitting}
+						disabled={isSubmitting}
+						type="submit">
+						{`Add`}
+					</Button>
+					<Button variant="outlined" className="outlined" onClick={() => handleOpen(false)}>
+						{`Cancel`}
+					</Button>
+				</div>
 			</div>
-			<div className="flex flex-col items-left">
-				<label htmlFor="card" className="text-xs text-gray-900 font-semibold ml-1">{'Card'}</label>
-				<input id="card" name="card" type="number" className={`formInput ${errors.card ? 'inputError' : ''}`} step={0.01}
-					{...register('card', { required: true, min: 0, valueAsNumber: true })} />
-				{errors.card && errors.card.type === 'required' &&
-					(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`This field is required`}</span>)}
-				{errors.card && errors.card.type === 'min' &&
-					(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`Amount must be a positive number or zero `}</span>)}
-			</div>
-		</div>
+		</form>
+
 	</>);
 
 	const newWithdrawal = (<>
-		<div className="flex flex-col gap-3">
-			<Typography variant="small" color="blue-gray">
-				{`This amount will be taken from your card income and goes to cash income.`}
-			</Typography>
-			<div className="flex flex-col items-left">
-				<label htmlFor="withdrawal" className="text-xs text-gray-900 font-semibold ml-1">{'Amount'}</label>
-				<input id="withdrawal" name="withdrawal" type="number" className={`formInput ${errors.withdrawal ? 'inputError' : ''}`} step={0.1}
-					{...register('withdrawal', { required: true, min: 0.1, valueAsNumber: true, max: cardAmountRemaining })} />
-				{errors.withdrawal && errors.withdrawal.type === 'required' &&
-					(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`This field is required`}</span>)}
-				{errors.withdrawal && errors.withdrawal.type === 'min' &&
-					(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`Amount must be a positive number`}</span>)}
-				{errors.withdrawal && errors.withdrawal.type === 'max' &&
-					(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`Amount can't be higher than the remaining in card ($${cardAmountRemaining})`}</span>)}
+		<form onSubmit={submitWithdrawal(onSubmit)} >
+			<div className="flex flex-col gap-4">
+				<span className="text-sm lg:text-[15px] text-blue-gray-800 antialiased">
+					{`This amount will be taken from your card income and goes to cash income.`}
+				</span>
+
+				<div className="flex flex-col items-left">
+					<label htmlFor="withdrawal" className="text-xs text-gray-900 font-semibold ml-1">{'Amount'}</label>
+					<input id="withdrawal" name="withdrawal" type="number" className={`formInput ${err.withdrawal ? 'inputError' : ''}`} step={0.1}
+						{...withdrawalRegister('withdrawal', { required: true, min: 0.1, valueAsNumber: true, max: cardAmountRemaining })} />
+					{err.withdrawal && err.withdrawal.type === 'required' &&
+						(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`This field is required`}</span>)}
+					{err.withdrawal && err.withdrawal.type === 'min' &&
+						(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`Amount must be a positive number`}</span>)}
+					{err.withdrawal && err.withdrawal.type === 'max' &&
+						(<span role="alert" className="text-xs text-red-700 font-normal mt-1 text-left">{`Amount can't be higher than the remaining in card ($${cardAmountRemaining})`}</span>)}
+				</div>
+				<div className="flex w-full justify-end gap-4 mt-4">
+					<Button variant="filled" className="filled"
+						loading={isSubmittingWithdrawal}
+						disabled={isSubmittingWithdrawal || !isValid}
+						type="submit">
+						{`Withdraw`}
+					</Button>
+					<Button variant="outlined" className="outlined" onClick={() => handleOpen(false)}>
+						{`Cancel`}
+					</Button>
+				</div>
 			</div>
-		</div>
+		</form>
 	</>);
 
 	return (<>
@@ -133,10 +163,10 @@ export default function AddIncomeDialog({ isOpen, handleOpen, cardAmountRemainin
 					</IconButton>
 				</div>
 			</DialogHeader>
-			<DialogBody className="min-w-full p-6">
+			<DialogBody className="min-w-full p-6 pb-1">
 				<div className="w-full flex flex-col gap-4">
 					<Typography variant="paragraph" id="income-dialog-description" color="blue-gray">{`Withdraw from card or directly add a new income for either payment method`}</Typography>
-					<form className="mt-8 mb-2" onSubmit={handleSubmit(onSubmit)} >
+					<div className="mt-2 mb-2">
 						<Tabs value="withdrawal">
 							<TabsHeader>
 								<Tab value="withdrawal" onClick={() => switchView(true)}>
@@ -146,27 +176,22 @@ export default function AddIncomeDialog({ isOpen, handleOpen, cardAmountRemainin
 									<span className="font-semibold text-blue-800">{`Income`}</span>
 								</Tab>
 							</TabsHeader>
-							<TabsBody>
-								<TabPanel value="withdrawal" className="w-full">
+							<TabsBody
+								animate={{
+									initial: { y: 250 },
+									mount: { y: 0 },
+									unmount: { y: 250 },
+								}}
+							>
+								<TabPanel value="withdrawal" className="w-full p-2">
 									{newWithdrawal}
 								</TabPanel>
-								<TabPanel value="income" className="w-full">
+								<TabPanel value="income" className="w-full pt-3 pb-2 px-2">
 									{newIncome}
 								</TabPanel>
 							</TabsBody>
 						</Tabs>
-						<div className="flex w-full justify-end gap-4">
-							<Button variant="filled" className="filled"
-								loading={isSubmitting}
-								disabled={isSubmitting}
-								type="submit">
-								{`Add`}
-							</Button>
-							<Button variant="outlined" className="outlined" onClick={() => handleOpen(false)}>
-								{`Cancel`}
-							</Button>
-						</div>
-					</form>
+					</div>
 				</div>
 			</DialogBody>
 		</Dialog>

--- a/components/simpleTable/tables/SimpleTable.tsx
+++ b/components/simpleTable/tables/SimpleTable.tsx
@@ -114,7 +114,7 @@ export default function SimpleTable({ expenses }: SimpleTablePropsI) {
 											{typeFilter(expense.type)}
 										</Typography>
 										{expense.isPending && (
-											<span className={`${classes.stroke} text-xs lg:text-sm text-indigo-500 font-semibold`}>{`Pending`}</span>
+											<span className={`${classes.activeStroke} text-[10px] text-indigo-400 font-normal`}>{`Pending`}</span>
 										)}
 									</div>
 								</td>
@@ -208,7 +208,7 @@ export default function SimpleTable({ expenses }: SimpleTablePropsI) {
 const PaymentBadge: React.FC = () => {
 	return (<>
 		<div className="w-2/3 lg:w-1/3 flex justify-center text-center p-1 rounded-xl bg-lime-400">
-			<Typography variant="small" color="blue-gray" className=" text-[10px] lg:text-[11px]">{`Payment`}</Typography>
+			<Typography variant="small" className="text-indigo-500 text-[10px] lg:text-[11px]">{`Payment`}</Typography>
 		</div>
 	</>);
 };

--- a/components/ui/main-header.tsx
+++ b/components/ui/main-header.tsx
@@ -89,7 +89,7 @@ export default function MainHeader() {
 						</div>
 					</div>
 
-					<Drawer open={open} onClose={closeDrawer} className="p-4 shadow-2xl shadow-blue-gray-900/80" >
+					<Drawer open={open} onClose={closeDrawer} className="p-4 bg-white shadow-2xl shadow-blue-gray-900/80" >
 						<div className="flex flex-col w-full ">
 							<div className="w-full flex justify-between items-center mb-8 ">
 								<Image src={logoImg} alt="Expenses logo" width={150} priority />
@@ -125,7 +125,7 @@ export default function MainHeader() {
 										<Link href="/reports">{`Reports`}</Link>
 									</li>
 									<li>
-										<Button variant="outlined" color="blue" onClick={logoutHandler} >{`Logout`}</Button>
+										<Button variant="outlined" className="outlined" color="blue" onClick={logoutHandler} >{`Logout`}</Button>
 									</li>
 
 								</>)}

--- a/services/expenses-calculator.ts
+++ b/services/expenses-calculator.ts
@@ -12,7 +12,7 @@ import { AddedIncomeI, ExpenseItemI, ExpensesTableI, PendingExpenseI, TotalsType
  * @returns An updated version of the table
  */
 export async function processAddIncome(newIncome: AddedIncomeI, existingTable: ExpensesTableI): Promise<ExpensesTableI> { //
-	const updatedTable = { ...existingTable };
+	const updatedTable: ExpensesTableI = JSON.parse(JSON.stringify(existingTable));
 	const addedArray = updatedTable.added || [];
 	const totalAdded = { cash: 0, card: 0, withdrawal: 0 };
 
@@ -45,15 +45,15 @@ export async function processAddIncome(newIncome: AddedIncomeI, existingTable: E
  * @returns An unpadated version of the expenses table
  */
 export async function processAddNewExpense(newClientExpense: ExpenseItemI, existingTable: ExpensesTableI): Promise<ExpensesTableI> { //
-	const updatedTable = { ...existingTable };
-	const expensesArray: ExpenseItemI[] = existingTable.expenses || [];
+	const updatedTable: ExpensesTableI = JSON.parse(JSON.stringify(existingTable));
+	const expensesArray: ExpenseItemI[] = updatedTable.expenses || [];
 	// const newId: number = expensesArray.length > 0 ? expensesArray[expensesArray.length - 1].id + 1 : 1;
 	const newId: string = expensesArray.length + 1 + newClientExpense.description.slice(0, 2).toLocaleUpperCase();
 
 	newClientExpense.id = newId;
 	expensesArray.push(newClientExpense);
 	const { totalExpenses, totalPendingPaid } = calculateExpensesTotals(expensesArray);
-	const { totalPending, pendingArray } = updatePendingAmount(expensesArray, existingTable.pending);
+	const { totalPending, pendingArray } = updatePendingAmount(expensesArray, updatedTable.pending);
 	updatedTable.expenses = expensesArray;
 	updatedTable.totals = updatedTable.totals || {
 		total_expenses: { cash: 0, card: 0 },

--- a/styles/text-stroke.module.css
+++ b/styles/text-stroke.module.css
@@ -2,3 +2,7 @@ span.stroke {
 	text-shadow:
 		4px 3px 10px rgba(87, 225, 133, 0.8);
 }
+
+span.activeStroke {
+	text-shadow: -3px 0px 2px var(--stroke-color), 3px 0px 2px var(--stroke-color), 0px -3px 2px var(--stroke-color), 0px 3px 2px var(--stroke-color);
+}


### PR DESCRIPTION
- Income and withdrawal forms have different rules and to prevent they end up interfering with one another, I had to split them in separated forms.
- processAddIncome, processAddPending, processAddNewExpense have now their own uniti tests: 
- - Test withdrawal logic, transfering a given amount from card to cash.
- - Test simple income addition, adding an amount to a given method, hence increase just that one.
- - Test pending expenses pushes a new entry in the pending array, updating pending totals object.
- - Test partial payment by adding an expense linked to a pending expense, making sure totals (expenses, pending and payments) along with remaining do the calculations properly.
- - Testing the scenario where a payment surpasses pending amount, in which case, panding amount must become 0, not a negative number.
- Update no content response status in API routes. 
- Add new style for pending badge in mobile