### PR TITLE
Fix: fullfill & close table buttons disabled, create new server function

### DIFF
--- a/app/__tests__/expenses/createSimpleTable.test.tsx
+++ b/app/__tests__/expenses/createSimpleTable.test.tsx
@@ -6,11 +6,39 @@ jest.mock('@material-tailwind/react', () => ({
 }));
 
 import CreateSimpleTableComponent from "@/components/simpleTable/createSimpleTableComponent";
+import { ExpensesTableI } from "@/interfaces/expenses";
+import { processStartNewPeriod } from "@/services/expenses-calculator";
 import { createTestQueryClient, renderWithQuery } from "@/utils/test-utils";
 import { QueryClient } from "@tanstack/react-query";
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+const mockTableData: ExpensesTableI = {
+	user_id: 'test@test.com',
+	_id: '507f1f77bcf86cd799439011',
+	totals: {
+		total_expenses: { cash: 100, card: 800 },
+		total_pending: { cash: 900, card: 1000 },
+		total_payments_made: { cash: 0, card: 300 }
+	},
+	remaining: { card: 1900, cash: 500 },
+	income: { cash: 600, card: 3000 },
+	added: [],
+	expenses: [
+		{ id: '1T', amount: 100, description: 'Groceries', type: 'cash', date: new Date().getTime(), isPending: false },
+		{ id: '2T', amount: 500, description: 'Rent', type: 'card', date: new Date().getTime(), isPending: false },
+		{ id: '3T', amount: 100, description: 'Pending test 1', type: 'card', date: new Date().getTime(), isPending: true, pending_id: 'P3' },
+		{ id: '5T', amount: 200, description: 'Pending test 2', type: 'card', date: new Date().getTime(), isPending: true, pending_id: 'P4' },
+	],
+	pending: [
+		{ id: 'P3', description: 'Pending test 3', originalAmount: 600, amount: 500, type: 'card', fulfilled: false },
+		{ id: 'P4', description: 'Pending test 4', originalAmount: 700, amount: 500, type: 'card', fulfilled: false },
+		{ id: 'P6', description: 'Pending test 6', originalAmount: 900, amount: 900, type: 'cash', fulfilled: false }
+	],
+	sDate: new Date().getTime(),
+	fDate: 0,
+	status: 'active'
+};
 describe('CreateSimpleTableComponent', () => {
 	let queryClient: QueryClient;
 	beforeEach(() => {
@@ -93,114 +121,124 @@ describe('CreateSimpleTableComponent', () => {
 			expect(screen.getByRole('button', { name: /Create table/i })).toBeDisabled();
 
 		});
+		it('resets form after successful submission', async () => {
+			// Mock successful response
+			(global.fetch as jest.Mock).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ success: true }),
+			});
+
+			renderWithQuery(<CreateSimpleTableComponent />, queryClient);
+			const user = userEvent.setup();
+			// Open dialog
+			await user.click(screen.getByRole('button', { name: /create new expenses table/i }));
+
+			const cashInput = screen.getAllByRole('spinbutton', { name: /amount/i })[0] as HTMLInputElement;
+			const cardInput = screen.getAllByRole('spinbutton', { name: /amount/i })[1] as HTMLInputElement;
+
+			// Fill form
+			await user.clear(cashInput);
+			await user.type(cashInput, '100');
+			await user.clear(cardInput);
+			await user.type(cardInput, '200');
+
+			// Verify values are filled
+			expect(cashInput.value).toBe('100');
+			expect(cardInput.value).toBe('200');
+
+			// Submit form
+			await user.click(screen.getByRole('button', { name: /create table/i }));
+
+			// Wait for mutation to complete and form to reset
+			await waitFor(() => {
+				expect(cashInput.value).toBe('0'); // Reset to default value
+				expect(cardInput.value).toBe('0');
+			});
+		});
 
 	});
 
-	it('calls mutation with correct data when form is submitted', async () => {
-		// Mock successful response
-		(global.fetch as jest.Mock).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ success: true }),
+	describe('Mutation behavior', () => {
+		it('calls mutation with correct data when form is submitted', async () => {
+			// Mock successful response
+			(global.fetch as jest.Mock).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ success: true }),
+			});
+
+			renderWithQuery(<CreateSimpleTableComponent />, queryClient);
+			const user = userEvent.setup();
+			// Open the dialog
+			const openButton = screen.getByRole('button', { name: /create new expenses table/i });
+			await user.click(openButton);
+
+			// Fill form
+			const cashInput = screen.getAllByRole('spinbutton', { name: /amount/i })[0];
+			const cardInput = screen.getAllByRole('spinbutton', { name: /amount/i })[1];
+
+			await user.clear(cashInput);
+			await user.type(cashInput, '100');
+			await user.clear(cardInput);
+			await user.type(cardInput, '200');
+
+			// Submit form
+			const submitButton = screen.getByRole('button', { name: /create table/i });
+			await user.click(submitButton);
+
+			// Verify fetch was called correctly
+			await waitFor(() => {
+				expect(global.fetch).toHaveBeenCalledWith(
+					'/api/expenses/table',
+					{
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify({ cash: 100, card: 200 }),
+					}
+				);
+			});
+		});
+		it('invalidates activeTable query after successful mutation', async () => {
+			// Mock successful response
+			(global.fetch as jest.Mock).mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ success: true }),
+			});
+
+			// Set initial query data
+			queryClient.setQueryData(['activeTable'], { data: null });
+
+			renderWithQuery(<CreateSimpleTableComponent />, queryClient);
+			const user = userEvent.setup();
+			// Open dialog and fill form
+			await user.click(screen.getByRole('button', { name: /create new expenses table/i }));
+
+			const cashInput = screen.getAllByRole('spinbutton', { name: /amount/i })[0];
+			const cardInput = screen.getAllByRole('spinbutton', { name: /amount/i })[1];
+
+			await user.clear(cashInput);
+			await user.type(cashInput, '100');
+			await user.clear(cardInput);
+			await user.type(cardInput, '200');
+
+			// Submit
+			await user.click(screen.getByRole('button', { name: /create table/i }));
+
+			// Verify query was invalidated
+			await waitFor(() => {
+				const queryState = queryClient.getQueryState(['activeTable']);
+				// After invalidation, query is marked as stale
+				expect(queryState?.isInvalidated).toBe(true);
+			});
 		});
 
-		renderWithQuery(<CreateSimpleTableComponent />, queryClient);
-		const user = userEvent.setup();
-		// Open the dialog
-		const openButton = screen.getByRole('button', { name: /create new expenses table/i });
-		await user.click(openButton);
+	});
 
-		// Fill form
-		const cashInput = screen.getAllByRole('spinbutton', { name: /amount/i })[0];
-		const cardInput = screen.getAllByRole('spinbutton', { name: /amount/i })[1];
-
-		await user.clear(cashInput);
-		await user.type(cashInput, '100');
-		await user.clear(cardInput);
-		await user.type(cardInput, '200');
-
-		// Submit form
-		const submitButton = screen.getByRole('button', { name: /create table/i });
-		await user.click(submitButton);
-
-		// Verify fetch was called correctly
-		await waitFor(() => {
-			expect(global.fetch).toHaveBeenCalledWith(
-				'/api/expenses/table',
-				{
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ cash: 100, card: 200 }),
-				}
-			);
+	describe('Server function', () => {
+		it('creates a new pending array based off of last closed table', async () => {
+			const mockSession = { expires: '0', user: { id: '1', email: 'test@mail.com' } };
+			const newTable = await processStartNewPeriod(mockTableData, mockSession, { card: 1000, cash: 200 });
+			expect(newTable.totals.total_pending.card).toBe(1300);
 		});
 	});
 
-	it('invalidates activeTable query after successful mutation', async () => {
-		// Mock successful response
-		(global.fetch as jest.Mock).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ success: true }),
-		});
-
-		// Set initial query data
-		queryClient.setQueryData(['activeTable'], { data: null });
-
-		renderWithQuery(<CreateSimpleTableComponent />, queryClient);
-		const user = userEvent.setup();
-		// Open dialog and fill form
-		await user.click(screen.getByRole('button', { name: /create new expenses table/i }));
-
-		const cashInput = screen.getAllByRole('spinbutton', { name: /amount/i })[0];
-		const cardInput = screen.getAllByRole('spinbutton', { name: /amount/i })[1];
-
-		await user.clear(cashInput);
-		await user.type(cashInput, '100');
-		await user.clear(cardInput);
-		await user.type(cardInput, '200');
-
-		// Submit
-		await user.click(screen.getByRole('button', { name: /create table/i }));
-
-		// Verify query was invalidated
-		await waitFor(() => {
-			const queryState = queryClient.getQueryState(['activeTable']);
-			// After invalidation, query is marked as stale
-			expect(queryState?.isInvalidated).toBe(true);
-		});
-	});
-
-	it('resets form after successful submission', async () => {
-		// Mock successful response
-		(global.fetch as jest.Mock).mockResolvedValueOnce({
-			ok: true,
-			json: async () => ({ success: true }),
-		});
-
-		renderWithQuery(<CreateSimpleTableComponent />, queryClient);
-		const user = userEvent.setup();
-		// Open dialog
-		await user.click(screen.getByRole('button', { name: /create new expenses table/i }));
-
-		const cashInput = screen.getAllByRole('spinbutton', { name: /amount/i })[0] as HTMLInputElement;
-		const cardInput = screen.getAllByRole('spinbutton', { name: /amount/i })[1] as HTMLInputElement;
-
-		// Fill form
-		await user.clear(cashInput);
-		await user.type(cashInput, '100');
-		await user.clear(cardInput);
-		await user.type(cardInput, '200');
-
-		// Verify values are filled
-		expect(cashInput.value).toBe('100');
-		expect(cardInput.value).toBe('200');
-
-		// Submit form
-		await user.click(screen.getByRole('button', { name: /create table/i }));
-
-		// Wait for mutation to complete and form to reset
-		await waitFor(() => {
-			expect(cashInput.value).toBe('0'); // Reset to default value
-			expect(cardInput.value).toBe('0');
-		});
-	});
 });

--- a/app/api/expenses/table/route.ts
+++ b/app/api/expenses/table/route.ts
@@ -1,6 +1,6 @@
 import { AddedIncomeI, ExpensesTableI, IncomeI } from "@/interfaces/expenses";
 import { setInitialValues } from "@/lib/user/simple-expenses";
-import { processAddIncome } from "@/services/expenses-calculator";
+import { processAddIncome, processStartNewPeriod } from "@/services/expenses-calculator";
 import { ObjectId } from "mongodb";
 import { NextResponse } from "next/server";
 
@@ -27,25 +27,9 @@ export async function POST(request: Request) { //Create new table
 			return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
 		}
 		const { session, client, collection } = await setInitialValues();
-		// const lastClosedQuery: { user_id: string, status: 'closed' } = { user_id: session.user.email, status: 'closed' };
-		// const lastClosed = await collection.findOne(lastClosedQuery, { sort: { fDate: -1 } });
-		// const newPendingArray = lastClosed ? lastClosed.pending.map(p => ({ amount: p.originalAmount, ...p })) : [];
-		const initialTableValues: Omit<ExpensesTableI, 'id' | '_id'> = {
-			user_id: session.user.email,
-			status: 'active',
-			income: { ...initialIncome },
-			sDate: new Date().getTime(),
-			totals: {
-				total_expenses: { cash: 0, card: 0 },
-				total_pending: { cash: 0, card: 0 },
-				total_payments_made: { cash: 0, card: 0 }
-			},
-			pending: [],
-			expenses: [],
-			added: [],
-			fDate: 0,
-			remaining: { ...initialIncome }
-		};
+		const lastClosedQuery: { user_id: string, status: 'closed' } = { user_id: session.user.email, status: 'closed' };
+		const lastClosed = await collection.findOne(lastClosedQuery, { sort: { fDate: -1 } });
+		const initialTableValues = await processStartNewPeriod(lastClosed, session, initialIncome);
 
 		await collection.insertOne(initialTableValues);
 		await client.close();

--- a/components/simpleTable/CloseActiveTableButton.tsx
+++ b/components/simpleTable/CloseActiveTableButton.tsx
@@ -65,7 +65,7 @@ export default function CloseActiveTableButton() {
 			</DialogBody>
 			<DialogFooter className="pt-0">
 				<div className="w-full flex gap-4 items-center justify-end">
-					<Button variant="filled" className="filled" onClick={handleCloseTable} >{`Close period`}</Button>
+					<Button variant="filled" className="filled" onClick={handleCloseTable} disabled={mutation.isPending} loading={mutation.isPending} >{`Close period`}</Button>
 					<Button variant="outlined" className="outlined" onClick={handleOpen}>{`Cancel`}</Button>
 				</div>
 			</DialogFooter>

--- a/components/simpleTable/expenses/EditPendingExpenseDialog.tsx
+++ b/components/simpleTable/expenses/EditPendingExpenseDialog.tsx
@@ -170,10 +170,10 @@ export function EditPendingExpenseDialog({ pending, isOpen, handleOpen }: EditPe
 							</div>
 						</TabPanel>
 						<TabPanel value="fulfill" className="w-full p-0">
-							<div className="flex flex-col w-full gap-3 p-1">
+							<div className="flex flex-col w-full gap-4 p-3 text-center mt-2">
 								<Text variant="body" id="edit-pending-description" >{`Mark this pending expense as fulfilled, this action turns its amount to 0`}</Text>
 								<div className="w-full flex justify-center">
-									<Button variant="outlined" className="outlined" disabled={pending.fulfilled} onClick={onFulfill}>
+									<Button variant="outlined" className="outlined" disabled={pending.fulfilled || fulfillMutation.isPending} loading={fulfillMutation.isPending} onClick={onFulfill}>
 										{`Fulfill`}
 									</Button>
 								</div>

--- a/components/simpleTable/income/AddedIncome.dialog.tsx
+++ b/components/simpleTable/income/AddedIncome.dialog.tsx
@@ -42,7 +42,7 @@ export default function AddedIncomeDialog({ addedIncome, isOpen, handleOpen }: A
 					</div>
 					<Text variant="body" id="income-dialog-description" className="mt-1">{`History of income additions and withdrawals`}</Text>
 
-					<div className="mt-3 max-h-96 overflow-y-auto">
+					<div className="mt-3 max-h-96 overflow-y-auto px-1">
 						{addedIncome.length === 0 ? (
 							<div className="text-center py-8">
 								<Text variant="label">

--- a/services/expenses-calculator.ts
+++ b/services/expenses-calculator.ts
@@ -1,6 +1,7 @@
 'use server';
 
-import { AddedIncomeI, ExpenseItemI, ExpensesTableI, PendingExpenseI, TotalsType } from "@/interfaces/expenses";
+import { AddedIncomeI, ExpenseItemI, ExpensesTableI, IncomeI, PendingExpenseI, TotalsI, TotalsType } from "@/interfaces/expenses";
+import { Session } from "next-auth";
 
 /**Server functions called from API routes */
 
@@ -146,7 +147,12 @@ export async function processAddPending(newClientPendingExpense: PendingExpenseI
 	return updatedTable;
 }
 
-
+/**
+ * 
+ * @param pendingExpense An edited pending expense object
+ * @param existingTable The current open table for the client
+ * @returns An updated version of the expenses table
+ */
 export async function processUpdatePendingExpenses(pendingExpense: PendingExpenseI, existingTable: ExpensesTableI): Promise<ExpensesTableI> {
 	const updatedTable = JSON.parse(JSON.stringify(existingTable));
 	const pendingArray: PendingExpenseI[] = updatedTable.pending;
@@ -208,8 +214,40 @@ export async function processDeletePendingExpense(pendingExpenseId: string, exis
 
 /**End pending expenses functions */
 
-//Pure computational sever functions
+/**Start new expenses period functions */
+/**
+ * 
+ * @param lastClosedTable Expenses table from previous period (ExpensesTableI[])
+ * @param session auth session
+ * @param initialIncome IncomeI granted by user
+ * @returns new Expenses Table object (ExpensesTableI) to be stored
+ */
+export async function processStartNewPeriod(lastClosedTable: ExpensesTableI | null, session: Session, initialIncome: IncomeI): Promise<Omit<ExpensesTableI, 'id' | '_id'>> {
+	let newPendingArray: PendingExpenseI[] = [];
+	let totalPending: TotalsType = { cash: 0, card: 0 };
+	if (lastClosedTable) {
+		newPendingArray = lastClosedTable.pending.map(p => ({ ...p, amount: p.originalAmount }));
+		totalPending = getPendingTotal(newPendingArray);
+	}
+	return {
+		user_id: session.user.email,
+		status: 'active',
+		income: { ...initialIncome },
+		sDate: new Date().getTime(),
+		totals: {
+			total_expenses: { cash: 0, card: 0 },
+			total_pending: totalPending,
+			total_payments_made: { cash: 0, card: 0 }
+		},
+		pending: newPendingArray,
+		expenses: [],
+		added: [],
+		fDate: 0,
+		remaining: { ...initialIncome }
+	};
+}
 
+//Pure computational sever functions
 /**
  * 
  * @param expenses An array of expenses


### PR DESCRIPTION
Fix: 

- Disable fulfilll button in pending expense edition when mutation is pending and when pending has been marked as fulfilled.
- Disable "close period" button when mutation is pending
- Organize createSimpleTable unit tests into blocks

Improve:

- Create simple table has its own server function that allows to keep track of previous pending expenses, re-starting them and consider their amounts for initial totals.
- Add unit test for server function in create active table suite
- Remove old server routine from API route to let it handle DB interactions only.
