### PR TITLE
Fix: Allow user to keep adding expenses to fullfilled pyaments

### DIFF
--- a/components/reports/movements/MovementsList.tsx
+++ b/components/reports/movements/MovementsList.tsx
@@ -16,9 +16,9 @@ const formatDate = (timestamp: number) => {
 export default function MovementsList({ movements }: { movements: AddedIncomeI[] }) {
 	const { formatValue } = useMoneyFilter();
 	const totalAdded: { cash: number, card: number, withdrawal: number } = movements.reduce((acc, currentValue) => {
-		acc['cash'] = acc['cash'] || 0 + currentValue.cash;
-		acc['card'] = acc['card'] || 0 + currentValue.card;
-		acc['withdrawal'] = acc['withdrawal'] || 0 + (currentValue.isWithdrawal ? currentValue.cash : 0);
+		acc['cash'] += currentValue.cash;
+		acc['card'] += currentValue.card;
+		acc['withdrawal'] += (currentValue.isWithdrawal ? currentValue.cash : 0);
 		return acc;
 	}, { card: 0, cash: 0, withdrawal: 0 });
 

--- a/components/simpleTable/expenses/AddExpensesDialog.tsx
+++ b/components/simpleTable/expenses/AddExpensesDialog.tsx
@@ -75,7 +75,7 @@ export default function AddExpensesDialog({ isPending, isOpen, handleOpen }: Exp
 		if (currentTable.pending.length === 0) return [];
 		const typeHasPending = hasTypePendingExpenses(currentTable.pending, watchType);
 		if (!typeHasPending) return [];
-		const newArray = currentTable.pending.filter((pendingExpense) => pendingExpense.type === watchType && !pendingExpense.fulfilled);
+		const newArray = currentTable.pending.filter((pendingExpense) => pendingExpense.type === watchType);
 		return newArray;
 	}, [isPending, watchType, currentTable]);
 

--- a/services/expenses-calculator.ts
+++ b/services/expenses-calculator.ts
@@ -228,7 +228,7 @@ export async function processStartNewPeriod(lastClosedTable: ExpensesTableI | nu
 	let newPendingArray: PendingExpenseI[] = [];
 	let totalPending: TotalsType = { cash: 0, card: 0 };
 	if (lastClosedTable) {
-		newPendingArray = lastClosedTable.pending.map(p => ({ ...p, amount: p.originalAmount }));
+		newPendingArray = lastClosedTable.pending.map(p => ({ ...p, amount: p.originalAmount, fulfilled: false }));
 		totalPending = getPendingTotal(newPendingArray);
 	}
 	return {


### PR DESCRIPTION
Fixes:
Allow user to keep adding payments to already fulfilled pending expenses.
Fix movements card totals in reports
Fix pending payments flagged as fulfilled when creating a new expenses period, flagged it back to unfulffiled.